### PR TITLE
Adds MachineUUID implemenation for Windows

### DIFF
--- a/internal/sys/machine_windows.go
+++ b/internal/sys/machine_windows.go
@@ -1,0 +1,22 @@
+// +build windows
+
+package sys
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+func MachineUUID() (uuid.UUID, error) {
+	// we use the output from the command `wmic csproduct get UUID`
+	cmd := exec.Command("wmic", "csproduct", "get", "UUID")
+	output, err := cmd.Output()
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	outputStr := strings.TrimSpace(strings.ReplaceAll(string(output), "UUID", ""))
+	return uuid.Parse(outputStr)
+}

--- a/internal/sys/machine_windows.go
+++ b/internal/sys/machine_windows.go
@@ -10,13 +10,15 @@ import (
 )
 
 func MachineUUID() (uuid.UUID, error) {
-	// we use the output from the command `wmic csproduct get UUID`
-	cmd := exec.Command("wmic", "csproduct", "get", "UUID")
+	// we use the output from the command `reg query HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography /v MachineGuid`
+	cmd := exec.Command("reg", "query", `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography`, "/v", "MachineGuid")
 	output, err := cmd.Output()
 	if err != nil {
 		return uuid.Nil, err
 	}
 
-	outputStr := strings.TrimSpace(strings.ReplaceAll(string(output), "UUID", ""))
-	return uuid.Parse(outputStr)
+	uuidStr := strings.ReplaceAll(string(output), `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography`, "")
+	uuidStr = strings.ReplaceAll(uuidStr, "MachineGuid", "")
+	uuidStr = strings.ReplaceAll(uuidStr, "REG_SZ", "")
+	return uuid.Parse(strings.TrimSpace(uuidStr))
 }


### PR DESCRIPTION
Hello, this PR implements the MachineUUID for Windows, it uses the registry key as mean for getting the uuid.

Ref: https://www.nextofwindows.com/the-best-way-to-uniquely-identify-a-windows-machine