### PR TITLE
Adds RootDiskUUID implementation for Windows

### DIFF
--- a/internal/sys/disk_windows.go
+++ b/internal/sys/disk_windows.go
@@ -1,0 +1,31 @@
+// +build windows
+
+package sys
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// RootDiskUUID returns the volume guid for the System Drive
+func RootDiskUUID() (uuid.UUID, error) {
+	systemDrive := os.Getenv("SystemDrive")
+
+	if systemDrive == "" {
+		return uuid.Nil, nil
+	}
+
+	cmd := exec.Command("mountvol", systemDrive, "/L")
+	output, err := cmd.Output()
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	uuidStr := strings.TrimSpace(string(output))
+	uuidStr = strings.TrimPrefix(uuidStr, `\\?\Volume{`)
+	uuidStr = strings.TrimSuffix(uuidStr, `}\`)
+	return uuid.Parse(uuidStr)
+}


### PR DESCRIPTION
This implementation uses the System Drive Volume GUID, I tried others ways, but this was the simplest.